### PR TITLE
Add UMAP DC paper

### DIFF
--- a/_bibliography/va.bib
+++ b/_bibliography/va.bib
@@ -86,6 +86,21 @@
 
 
 
+@inproceedings{DBLP:conf/um/Sebastian24,
+  author       = {Ratan Sebastian},
+  title        = {Adaptive Search Support for Teachers in Lesson Planning},
+  booktitle    = {Conference on User Modeling,Adaptation and Personalization, {UMAP} Adjunct 2024, Cagliari, Italy,July 1-4, 2024},
+  publisher    = {{ACM}},
+  year         = {2024},
+  url_          = {https://doi.org/10.1145/3631700.3664921},
+  doi          = {10.1145/3631700.3664921},
+  timestamp    = {Thu, 04 Jul 2024 22:05:46 +0200},
+  biburl       = {https://dblp.org/rec/conf/um/Sebastian24.bib},
+  bibsource    = {dblp computer science bibliography, https://dblp.org}
+}
+
+
+
 #######################################################################################################################
 # SUSHIL AWALE
 #######################################################################################################################


### PR DESCRIPTION
Note I have remove the "Adjunct Proceedings of" part of the book title per the unification guidelines. But the "Adjunct" part might be important. Let me know if I should put it back.